### PR TITLE
updated to enqueue assets on cpt edit page

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -81,7 +81,7 @@ class Plugin {
 
     public function enqueueAssets() {
         global $pagenow;
-        if (!in_array($pagenow, array('post.php', 'post-new.php', 'admin.php'))) {
+        if (!in_array($pagenow, array('post.php', 'post-new.php', 'admin.php', 'edit.php')) || ($pagenow == 'edit.php' && !isset($_GET['page']))) {
             return;
         }
         $this->registerAssets();


### PR DESCRIPTION
when making a setting page for a cpt the url is edit.php?post_type=CPT&page=SETTINGS_SLUG so the assets werent being enqueued. This fix will only enqueue assets for edit.php if the page var is set.